### PR TITLE
Update Xquik entry with GitHub repo link

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Please cite this repository as:
 + [The Herd Locker](http://theherdlocker.com/) - 90% of Twitter conversations are noise. Free service tracks audience-selected hashtags filtering out retweets, requotes and people sharing the stuff you've already seen but which is obscured by URL shorteners - highlighting the popular, and leaders who share it early in realtime and as a weekly digest.
 + [ExportData](https://www.exportdata.io/) - No-code tool to download Twitter followers & followings, export historical tweets and historical trends.
 + [Twitter Purge](https://github.com/wslyvh/twitter-purge) - Automatically deletes old tweets from your timeline to reduce your digital footprint 🧹
-+ [Xquik](https://xquik.com) - All-in-one X automation platform with REST API, MCP server & webhooks. 40+ tools for tweet search, user lookup, follower extraction, engagement metrics, giveaway draws, trending topics, write actions and media download.
++ [Xquik](https://xquik.com) ([GitHub](https://github.com/Xquik-dev/tweetclaw)) - All-in-one X/Twitter automation platform. Post tweets, reply, like, retweet, follow, DM, search, extract data (20 tools), run giveaway draws, monitor accounts, compose optimized tweets, download media. REST API, MCP server, webhooks. OpenClaw plugin.
 
 + [RemoteOpenClaw](https://remoteopenclaw.com) - Open marketplace for AI skills and personas built on OpenClaw.
 


### PR DESCRIPTION
## Summary
- Add [TweetClaw GitHub repo](https://github.com/Xquik-dev/tweetclaw) link to the existing Xquik entry
- Expand description to cover write actions (post, reply, like, retweet, follow, DM), data extraction (20 tools), giveaway draws, account monitoring, tweet composition, media download, and OpenClaw plugin support

No new entries added — just updating the existing one with more detail and a source code link.