### PR TITLE
Add UniStyle

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ Please cite this repository as:
 + [TweetClaw](https://github.com/Xquik-dev/tweetclaw) - OpenClaw plugin for X/Twitter automation: search tweets, post tweets and replies, export followers, run monitors and webhooks, send DMs, and run giveaway draws through Xquik.
 
 + [RemoteOpenClaw](https://remoteopenclaw.com) - Open marketplace for AI skills and personas built on OpenClaw.
++ [UniStyle](https://unistyle.io) - Convert plain text to 20+ Unicode styles (bold, italic, script, monospace) that paste into tweets and bios where Markdown isn't rendered.
 
 <!-- Browser Extensions -->
 ## Browser Extensions


### PR DESCRIPTION
Adding UniStyle to the list.

UniStyle is a free Unicode text formatter at https://unistyle.io. It converts plain text into 20+ Unicode styles (bold, italic, bold italic, script, fraktur, double-struck, monospace, small caps, vaporwave, strikethrough, underline, and more) that paste directly into any text field rendering Unicode - Twitter/X, Discord, Notion, Slack, LinkedIn, Instagram, and so on. The output is actual Unicode characters, not Markdown, so it works in fields that strip Markdown.

Why it fits the list: Twitter/X does not render Markdown anywhere - not in tweets, replies, bios, or display names. Unicode styling is the de facto way users format text on the platform, and UniStyle is a dedicated, no-signup tool for generating it.

- No signup, no accounts, no tracking, no ads.
- Open source: https://github.com/azmordis/simple-text-formatter
- PWA installable on desktop and Android.

Happy to adjust the entry's section, format, or wording if it doesn't match the list's conventions.
