### PR TITLE
Add Filaxy Herald to Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ Please cite this repository as:
 
 + [RemoteOpenClaw](https://remoteopenclaw.com) - Open marketplace for AI skills and personas built on OpenClaw.
 + [UniStyle](https://unistyle.io) - Convert plain text to 20+ Unicode styles (bold, italic, script, monospace) that paste into tweets and bios where Markdown isn't rendered.
++ [Filaxy Herald](https://github.com/othmarodev/filaxy-herald) - Open-source build-in-public bot that drafts posts from your GitHub activity and publishes approved ones to X via the API. You review each draft on Telegram (✅/❌) before it goes out, and a guardrail strips secrets first. Self-hostable, MIT, Node.js.
 
 <!-- Browser Extensions -->
 ## Browser Extensions


### PR DESCRIPTION
Hi @hridaydutta123, thanks for curating this list 🙏

Adding **Filaxy Herald** to the **Tools** section.

It's an open-source, self-hostable bot that drafts build-in-public posts from your GitHub activity and publishes approved ones to X via the API. You review each draft on Telegram (✅/❌) before it goes out, and a guardrail strips secrets first.

**Why it fits:** it's a tool that programmatically posts to X (write workflow via the X API), in the same vein as existing automation/posting entries in the list (e.g. `Coopboost`, `Twitter Purge`, `TweetClaw`). Free and self-hostable.

- Repo: https://github.com/othmarodev/filaxy-herald
- License: MIT · Node.js

One-line addition appended to the end of the Tools section. Happy to tweak the description or move it if you prefer.