### PR TITLE
Add The Free X Growth Course

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ Please cite this repository as:
 + [RemoteOpenClaw](https://remoteopenclaw.com) - Open marketplace for AI skills and personas built on OpenClaw.
 + [UniStyle](https://unistyle.io) - Convert plain text to 20+ Unicode styles (bold, italic, script, monospace) that paste into tweets and bios where Markdown isn't rendered.
 + [Filaxy Herald](https://github.com/othmarodev/filaxy-herald) - Open-source build-in-public bot that drafts posts from your GitHub activity and publishes approved ones to X via the API. You review each draft on Telegram (✅/❌) before it goes out, and a guardrail strips secrets first. Self-hostable, MIT, Node.js.
++ [The Free X Growth Course](https://slappost.app/learn/) - Free, no-login course with 5 lessons on growing on X (Twitter): hooks, threads, X's open-source algorithm, replies, and your profile funnel.
 
 <!-- Browser Extensions -->
 ## Browser Extensions


### PR DESCRIPTION
This PR adds **The Free X Growth Course** to the Tools section.

It's a completely free, no-login, no-email-wall course of 5 lessons on growing on X (Twitter): writing hooks, building threads, understanding X's open-source algorithm, working replies, and turning your profile into a funnel.

I placed it at the end of the Tools section, matching the existing `+` item format and noting that it's free with no login required. Thanks for maintaining this list!