### PR TITLE
Add X (Twitter) Marketing Skills (Claude Code + Codex) to Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ Please cite this repository as:
 + [UniStyle](https://unistyle.io) - Convert plain text to 20+ Unicode styles (bold, italic, script, monospace) that paste into tweets and bios where Markdown isn't rendered.
 + [Filaxy Herald](https://github.com/othmarodev/filaxy-herald) - Open-source build-in-public bot that drafts posts from your GitHub activity and publishes approved ones to X via the API. You review each draft on Telegram (✅/❌) before it goes out, and a guardrail strips secrets first. Self-hostable, MIT, Node.js.
 + [The Free X Growth Course](https://slappost.app/learn/) - Free, no-login course with 5 lessons on growing on X (Twitter): hooks, threads, X's open-source algorithm, replies, and your profile funnel.
++ [X (Twitter) Marketing Skills](https://github.com/sergebulaev/x-skills) - Open-source Claude Code and Codex skill bundle to write tweets and threads with corpus-validated hook formulas, extract hooks from viral tweets, draft replies, and read your niche via Apify. MIT.
 
 <!-- Browser Extensions -->
 ## Browser Extensions


### PR DESCRIPTION
Adds [sergebulaev/x-skills](https://github.com/sergebulaev/x-skills) to Tools: open-source Claude Code and Codex skill bundle to write tweets and threads with corpus-validated hook formulas, extract hooks from viral tweets, draft replies, and read your niche from real data via Apify. MIT, part of a 7-platform social-media marketing family. Matched the existing entry format.