### PR TITLE
Add TweetAPI to Tools section

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ Please cite this repository as:
 
 + [Sorsa API](https://docs.sorsa.io) - A real-time X (Twitter) data API providing tweets, profiles, search, communities and verification. Up to 50x cheaper than the official X API.
 + [TwitterAPI.io](https://twitterapi.io) - Real-time X (Twitter) data API providing tweets, profiles, search, and user lookups. Pay-as-you-go from $0.15 per 1K tweets, sub-500ms latency, 1000+ req/sec.
++ [TweetAPI](https://tweetapi.com) - Third-party Twitter API for public posts, profiles, followers, search, and account workflows, with REST, Node/Python SDKs, and hosted MCP for read-only agent access. Start with 100 free requests; paid plans from $17/month.
 + [Tweepy](https://github.com/tweepy/tweepy) - An easy-to-use Python library for accessing the Twitter API.
 + [Twython](https://github.com/ryanmcgrath/twython) - Actively maintained, pure Python wrapper for the Twitter API.
 + [TwitterAPI](https://github.com/geduldig/TwitterAPI) - Minimal python wrapper for Twitter's REST and Streaming APIs


### PR DESCRIPTION
I'd like to add [TweetAPI](https://tweetapi.com) to the Tools section. It's a third-party Twitter API for public data and account workflows, with Node/Python SDKs and a hosted MCP server.

I kept it to a single entry to match the rest of the list. Happy to adjust the wording or placement if needed.
