### PR TITLE
Add twitter-archive-viewer to Tools in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ Please cite this repository as:
 + [Filaxy Herald](https://github.com/othmarodev/filaxy-herald) - Open-source build-in-public bot that drafts posts from your GitHub activity and publishes approved ones to X via the API. You review each draft on Telegram (✅/❌) before it goes out, and a guardrail strips secrets first. Self-hostable, MIT, Node.js.
 + [The Free X Growth Course](https://slappost.app/learn/) - Free, no-login course with 5 lessons on growing on X (Twitter): hooks, threads, X's open-source algorithm, replies, and your profile funnel.
 + [X (Twitter) Marketing Skills](https://github.com/sergebulaev/x-skills) - Open-source Claude Code and Codex skill bundle to write tweets and threads with corpus-validated hook formulas, extract hooks from viral tweets, draft replies, and read your niche via Apify. MIT.
++ [twitter-archive-viewer](https://github.com/Deviloxide/twitter-archive-viewer) - A lightweight, private viewer for exploring and searching your downloaded Twitter (X) data archives offline.
 
 <!-- Browser Extensions -->
 ## Browser Extensions


### PR DESCRIPTION
Hi! I'd like to add twitter-archive-viewer to the Tools section. It is a lightweight tool for viewing downloaded Twitter archive data locally and privately. I tried to use the default provided by Twitter and ran into a litany of issues, so I worked on this. The only change in this repo is that I added a new entry for 'twitter-archive-viewer' in the README.