### PR TITLE
Add Not for You to Browser Extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ Please cite this repository as:
 + [Twitter Volume Control](https://chrome.google.com/webstore/detail/twitter-volume-control/geeghoallaenmelpkedpgjpllljkfeap) - Adds a volume slider to twitter videos
 + [Twitter Video Downloader](https://chrome.google.com/webstore/detail/twitter%E7%94%A8%E3%81%AE%E3%83%93%E3%83%87%E3%82%AA%E3%83%80%E3%82%A6%E3%83%B3%E3%83%AD%E3%83%BC%E3%83%80%E3%83%BC/nmhepkajegobkleolkjfnleahifmilfj?hl=en) - Download your favorite videos or images on Twitter.
 + [Xbase — Twitter Bookmark Manager](https://chromewebstore.google.com/detail/xbase-%E2%80%94-get-more-out-of-x/ipldmffgjegnflofelcomladejjllfli?hl=en) - Upgrade your Twitter with our powerful twitter bookmark manager, with instant search, tags and note-taking.
++ [Not for You](https://chromewebstore.google.com/detail/not-for-you/pakdneaipkfgaahgbafblmdebfoadjca) - Turns off the For You timeline, trends and suggested accounts, so X stops deciding what you see. Does the same on YouTube, Instagram, TikTok, Reddit, LinkedIn, Threads and Facebook. Open source.
 
 <!-- Research Papers -->
 ## Research Papers


### PR DESCRIPTION
Not for You is an open-source (MIT) browser extension that opens X on the Following timeline instead of For You and hides trends and suggested accounts, so X stops deciding what you see. It does the same on YouTube, Instagram, TikTok, Reddit, LinkedIn, Threads and Facebook.

- Source: https://github.com/preziotte/not-for-you
- Chrome Web Store: https://chromewebstore.google.com/detail/not-for-you/pakdneaipkfgaahgbafblmdebfoadjca
- Firefox Add-ons: https://addons.mozilla.org/firefox/addon/notforyou/

Disclosure: I am the author.
